### PR TITLE
Fix a problem with small image URL being used instead of medium or big

### DIFF
--- a/Diveboard/Classes/Global/DiveInformation.m
+++ b/Diveboard/Classes/Global/DiveInformation.m
@@ -266,10 +266,7 @@
     
 }
 -(NSString *)urlString{
-    
-    
-    return self.smallURL;
-    
+
     if ([AppManager sharedManager].userSettings.pictureQuality == UserSettingPictureQualityTypeHigh) {
         
         return self.largeURL;


### PR DESCRIPTION
The Dive Info always returns the small image URL, bypassing the user setting to use medium or large images.
This leads to bad image quality on the photo gallery when displaying pictures in full screen